### PR TITLE
Track and export ad view counts

### DIFF
--- a/get_cookies.py
+++ b/get_cookies.py
@@ -138,9 +138,9 @@ class PlaywrightClient:
             await self.launch_browser()
             return await self.load_page(url)
         finally:
-            if hasattr(self, "browser"):
+            if self.browser is not None:
                 await self.browser.close()
-            if hasattr(self, "playwright"):
+            if getattr(self, "playwright", None) is not None:
                 await self.playwright.stop()
 
     async def get_cookies(self, url: str) -> dict:

--- a/models.py
+++ b/models.py
@@ -145,6 +145,8 @@ class Item(BaseModel):
     isSparePartsCompatibility: bool | None = None
     sellerId: str | None = None
     isPromotion: bool = False
+    views: int | None = None
+    viewsToday: int | None = None
 
 
 class ItemsResponse(BaseModel):

--- a/parser_cls.py
+++ b/parser_cls.py
@@ -168,6 +168,9 @@ class AvitoParse:
 
                 filter_ads = self.filter_ads(ads=ads)
 
+                for ad in filter_ads:
+                    self.fetch_views(ad)
+
                 if self.tg_handler:
                     self._send_to_tg(ads=filter_ads)
 
@@ -198,6 +201,38 @@ class AvitoParse:
         except Exception as err:
             logger.error(f"Ошибка при поиске информации на странице: {err}")
         return {}
+
+    def fetch_views(self, ad: Item) -> None:
+        url = f"https://www.avito.ru/{ad.urlPath}"
+        html_code = self.fetch_data(url=url, retries=self.config.max_count_of_retry)
+        if not html_code:
+            return
+
+        data = self.find_json_on_page(html_code=html_code)
+        total, today = self._extract_views_from_json(data)
+        ad.views = total
+        ad.viewsToday = today
+
+    @staticmethod
+    def _extract_views_from_json(data: dict) -> tuple[int | None, int | None]:
+        def search(obj):
+            if isinstance(obj, dict):
+                if {'total', 'today'}.issubset(obj.keys()):
+                    return obj.get('total'), obj.get('today')
+                if {'count', 'today'}.issubset(obj.keys()):
+                    return obj.get('count'), obj.get('today')
+                for value in obj.values():
+                    res = search(value)
+                    if res != (None, None):
+                        return res
+            elif isinstance(obj, list):
+                for item in obj:
+                    res = search(item)
+                    if res != (None, None):
+                        return res
+            return (None, None)
+
+        return search(data)
 
     def filter_ads(self, ads: list[Item]) -> list[Item]:
         """Сортирует объявления"""

--- a/xlsx_service.py
+++ b/xlsx_service.py
@@ -40,6 +40,8 @@ class XLSXHandler:
             "Координаты",
             "Изображения",
             "Поднято",
+            "Просмотры",
+            "Просмотры сегодня",
         ])
         workbook.save(self.file_name)
 
@@ -92,7 +94,9 @@ class XLSXHandler:
                 self.get_item_address_user(ad=ad),
                 self.get_item_coords(ad=ad),
                 ";".join(images_urls),
-                "Да" if ad.isPromotion else "Нет"
+                "Да" if ad.isPromotion else "Нет",
+                ad.views,
+                ad.viewsToday,
             ]
             sheet.append(row)
 


### PR DESCRIPTION
## Summary
- add view counters to Item model
- fetch views for each ad via new `fetch_views` method
- include views in Excel export with new columns
- avoid `NoneType` crash when closing browser in cookie retrieval

## Testing
- `python -m py_compile models.py parser_cls.py xlsx_service.py get_cookies.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4919a4b848329a87172a528f5a005